### PR TITLE
Add a comment telling where this script came from

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Minimalistic shell script to deploy Git repositories.
+# Run deploy --help for usage info.  Released under the MIT License.
+#
+# https://github.com/visionmedia/deploy
+
 VERSION="0.4.0"
 CONFIG=./deploy.conf
 LOG=/tmp/deploy.log


### PR DESCRIPTION
Because I don't want to burden developers with installing more software on their machines, I usually check the deploy script into the repository that I want to deploy.  We execute it like this:

```
./deploy dev
```

Works great.  Only problem is, there's no clue where the script came from so devs won't know where to go for updates or wiki info.  (I do add a comment before checking it in to my repo but that gets tedious and sometimes i forget...)
