### PR TITLE
Ensure all changes are committed and pushed before deploying

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -309,8 +309,9 @@ require_env() {
 #
 
 check_for_local_changes() {
-  git --no-pager diff --exit-code --quiet || abort "commit or stash your changes before deploying"
-  [ -z "`git rev-list @{upstream}.. -n 1 --quiet`" ] || abort "push your changes before deploying"
+  git --no-pager diff --exit-code --quiet          || abort "commit or stash your changes before deploying"
+  git --no-pager diff --exit-code --quiet --cached || abort "commit your staged changes before deploying"
+  [ -z "`git rev-list @{upstream}.. -n 1`" ]       || abort "push your changes before deploying"
 }
 
 #


### PR DESCRIPTION
I've gone nuts trying to figure out why my changes haven't fixed anything, only to discover that I forgot to push before deploying.

This patch ensures that will no longer be a problem for me.
