### PR TITLE
adding -t to the ssh command

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -115,7 +115,7 @@ ssh_command() {
 
   test -n "$forward_agent" && local agent="-A"
   test -n "$key" && local identity="-i $key"
-  echo "ssh $agent $identity $url"
+  echo "ssh -t $agent $identity $url"
 }
 
 #


### PR DESCRIPTION
I noticed that on some server the command is not being executed
without the -t.
