### PR TITLE
Add option to config to ensure ssh allocates a tty

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -98,7 +98,14 @@
   Now the deploy script will invoke `ssh -A` when deploying and there's
   no need to keep SSH keys on your servers.
 
-### Hooks
+### needs_tty
+
+  If your deployment scripts require any user interaction (which they shouldn't, but
+  often do) you'll probably want SSH to allocate a tty for you. Put `needs_tty yes`
+  in the config section if you'd like the deploy script to invoke `ssh -t` and ensure
+  you have a tty available.
+
+## Hooks
 
   All hooks are arbitrary commands, executed relative to `path/current`,
   aka the previous deployment for `pre-deploy`, and the new deployment

--- a/bin/deploy
+++ b/bin/deploy
@@ -113,11 +113,13 @@ ssh_command() {
   local key="`config_get key`"
   local forward_agent="`config_get forward-agent`"
   local port="`config_get port`"
+  local needs_tty="`config_get needs_tty`"
 
   test -n "$forward_agent" && local agent="-A"
   test -n "$key" && local identity="-i $key"
   test -n "$port" && local port="-p $port"
-  echo "ssh $agent $port $identity $url"
+  test -n "$needs_tty" && local tty="-t"
+  echo "ssh $tty $agent $port $identity $url"
 }
 
 #


### PR DESCRIPTION
Ensures that `ssh` allocates a tty (using `ssh -t`) if the option
`needs_tty` is set in the relevant config section.

Proper deployment setups (with a `deployer` user who doesn't require
a tty to `sudo`) shouldn't need this, but it's very useful for ad-hoc
setups that are making the move from manual to semi-automated deploys.
