### PR TITLE
Fix revert behavior, add ability to run local tests before a deploy

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -223,7 +223,12 @@ deploy() {
   local path=`config_get path`
   log deploying
 
-  local_hook local-test || abort local-test hook failed
+  if test $TEST -eq 1; then
+	local_hook local-test || abort local tests failed!
+  else
+    log ignoring local tests
+  fi
+
   hook pre-deploy || abort pre-deploy hook failed
 
   # fetch source

--- a/bin/deploy
+++ b/bin/deploy
@@ -206,6 +206,9 @@ hook() {
 setup() {
   local path=`config_get path`
   local repo=`config_get repo`
+
+  hook pre-setup || abort pre-setup hook failed
+
   run "mkdir -p $path/{shared/{logs,pids},source}"
   test $? -eq 0 || abort setup paths failed
   log running setup
@@ -214,6 +217,9 @@ setup() {
   test $? -eq 0 || abort failed to clone
   run "ln -sfn $path/source $path/current"
   test $? -eq 0 || abort symlink failed
+
+  hook post-setup || abort post-setup hook failed
+
   log setup complete
 }
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -11,6 +11,7 @@ VERSION="0.6.1-necaris"
 CONFIG=./deploy.conf
 LOG=/tmp/deploy.log
 TEST=1
+STRICT_KEYS=1
 REF=
 ENV=
 
@@ -28,6 +29,7 @@ usage() {
     -C, --chdir <path>   change the working directory to <path>
     -c, --config <path>  set config path. defaults to ./deploy.conf
     -T, --no-tests       ignore test hook
+    -K, --no-strict-keys skip strict host key checking
     -V, --version        output program version
     -h, --help           output help information
 
@@ -119,7 +121,8 @@ ssh_command() {
   test -n "$key" && local identity="-i $key"
   test -n "$port" && local port="-p $port"
   test -n "$needs_tty" && local tty="-t"
-  echo "ssh $tty $agent $port $identity $url"
+  test $STRICT_KEYS -eq 0 && local strict_keys="-o StrictHostKeyChecking=no"
+  echo "ssh $strict_keys $tty $agent $port $identity $url"
 }
 
 #
@@ -375,6 +378,7 @@ while test $# -ne 0; do
     -c|--config) set_config_path $1; shift ;;
     -C|--chdir) log cd $1; cd $1; shift ;;
     -T|--no-tests) TEST=0 ;;
+    -K|--no-strict-keys) STRICT_KEYS=0 ;;
     run|exec) require_env; run "cd `config_get path`/current && $@"; exit ;;
     console) require_env; console; exit ;;
     curr|current) require_env; current_commit; exit ;;

--- a/bin/deploy
+++ b/bin/deploy
@@ -268,7 +268,7 @@ current_commit() {
 nth_deploy_commit() {
   local n=$1
   local path=`config_get path`
-  run "cat $path/.deploys | tail -n $n | head -n 1 | cut -d ' ' -f 1"
+  run "cat $path/.deploys | tail -n $n | head -n 1 | cut -d ' ' -f 1 | tr -d '\n'"
 }
 
 #

--- a/bin/deploy
+++ b/bin/deploy
@@ -156,6 +156,26 @@ config() {
 }
 
 #
+# Execute hook <name> in the developer's repository, before
+# deploying code to the server
+#
+
+local_hook() {
+  test -n "$1" || abort hook name required
+  local hook=$1
+  local path=`config_get path`
+  local cmd=`config_get $hook`
+  if test -n "$cmd"; then
+    log "executing $hook \`$cmd\` in local repository"
+	($cmd 2>&1 | tee -a $LOG && exit ${PIPESTATUS})
+    test $? -eq 0
+  else
+    log local_hook $hook
+  fi
+}
+
+
+#
 # Execute hook <name> relative to the path configured.
 #
 
@@ -203,6 +223,7 @@ deploy() {
   local path=`config_get path`
   log deploying
 
+  local_hook local-test || abort local-test hook failed
   hook pre-deploy || abort pre-deploy hook failed
 
   # fetch source

--- a/bin/deploy
+++ b/bin/deploy
@@ -7,7 +7,7 @@
 # https://github.com/visionmedia/deploy
 #
 
-VERSION="0.6.0"
+VERSION="0.6.1-necaris"
 CONFIG=./deploy.conf
 LOG=/tmp/deploy.log
 TEST=1
@@ -356,7 +356,7 @@ check_for_local_changes() {
 update() {
   log "updating deploy(1)"
   rm -fr /tmp/deploy
-  git clone git://github.com/visionmedia/deploy.git \
+  git clone git://github.com/necaris/deploy.git \
     --depth 0 \
     /tmp/deploy \
     &> /tmp/deploy.log \

--- a/bin/deploy
+++ b/bin/deploy
@@ -229,6 +229,8 @@ deploy() {
     log ignoring local tests
   fi
 
+  # run any local tasks e.g. cache-busting
+  local_hook local-pre-deploy || abort local-pre-deploy failed
   hook pre-deploy || abort pre-deploy hook failed
 
   # fetch source


### PR DESCRIPTION
Remove trailing newline in the ref fetched from from `nth_deploy_commit()`, which blocks `git reset` working properly.

Also, add the ability to run tests locally on the developer's machine before a deploy.
