### PR TITLE
Logic to sort the tags was wrong.

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -214,7 +214,7 @@ deploy() {
   if test -z "$ref"; then
     log fetching latest tag
     ref=`run "cd $path/source && git for-each-ref refs/tags \
-      --sort=-authordate \
+      --sort=-*authordate \
       --format='%(refname)' \
       --count=1 | cut -d '/' -f 3"`
     test $? -eq 0 || abort failed to determine latest tag


### PR DESCRIPTION
Currently the way the tags are sorted is some random order. See the difference below.

**Current way of sorting:** `--sort=-authordate`

```
$ git for-each-ref refs/tags --sort=-authordate --format='%(refname)'
refs/tags/v0.1.10
refs/tags/v0.1.7
refs/tags/v0.1.6
refs/tags/v0.1.4
refs/tags/v0.1.13
refs/tags/v0.1.2
refs/tags/v0.1.3
refs/tags/v0.1.5
refs/tags/v0.1.8
refs/tags/v0.1.0
refs/tags/v0.1.9
refs/tags/v0.1.1
refs/tags/v0.1.11
refs/tags/v0.1.12

```

**After the fix:** `--sort=-*authordate`

```
$ git for-each-ref refs/tags --sort=-*authordate --format='%(refname)'
refs/tags/v0.1.13
refs/tags/v0.1.12
refs/tags/v0.1.11
refs/tags/v0.1.9
refs/tags/v0.1.8
refs/tags/v0.1.5
refs/tags/v0.1.3
refs/tags/v0.1.2
refs/tags/v0.1.1
refs/tags/v0.1.0
refs/tags/v0.1.10
refs/tags/v0.1.6
refs/tags/v0.1.4
refs/tags/v0.1.7
```
