### PR TITLE
when a directive is obtained, it is misplaced in a multi-env situation.

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -91,6 +91,7 @@ config_get() {
   local key=$1
   test -n "$key" \
     && grep "^\[$ENV" -A 20 $CONFIG \
+    | grep "^\[" -B 20 \
     | grep "^$key" \
     | head -n 1 \
     | cut -d ' ' -f 2-999


### PR DESCRIPTION
Should get an expected value of 22 when execute `deploy stage`
but config_get port equals 29

use this deploy.conf
```
[stage]

[production]
port 29
```

